### PR TITLE
Add optional user data to Point

### DIFF
--- a/martinez/contour.py
+++ b/martinez/contour.py
@@ -1,18 +1,20 @@
 from functools import reduce
 from operator import add
-from typing import (Iterator,
+from typing import (Generic,
+                    Iterator,
                     List)
 
 from reprit.base import generate_repr
 
 from .bounding_box import BoundingBox
+from .hints import T
 from .point import Point
 
 
-class Contour:
+class Contour(Generic[T]):
     __slots__ = '_points', '_holes', 'is_external'
 
-    def __init__(self, points: List[Point], holes: List[int], is_external: bool
+    def __init__(self, points: List[Point[T]], holes: List[int], is_external: bool
                  ) -> None:
         self._points = points
         self._holes = holes
@@ -20,11 +22,11 @@ class Contour:
 
     __repr__ = generate_repr(__init__)
 
-    def __iter__(self) -> Iterator[Point]:
+    def __iter__(self) -> Iterator[Point[T]]:
         return iter(self._points)
 
     @property
-    def points(self) -> List[Point]:
+    def points(self) -> List[Point[T]]:
         return self._points
 
     @property
@@ -58,7 +60,7 @@ class Contour:
                 if isinstance(other, Contour)
                 else NotImplemented)
 
-    def add(self, point: Point) -> None:
+    def add(self, point: Point[T]) -> None:
         self._points.append(point)
 
     def add_hole(self, hole: int) -> None:

--- a/martinez/hints.py
+++ b/martinez/hints.py
@@ -1,5 +1,10 @@
 from decimal import Decimal
 from numbers import Real
-from typing import TypeVar
+from typing import (Callable,
+                    TypeVar)
 
 Scalar = TypeVar('Scalar', Real, Decimal)
+
+T = TypeVar('T')
+
+UserLerp = Callable[[T, T, Scalar], T]

--- a/martinez/point.py
+++ b/martinez/point.py
@@ -1,17 +1,21 @@
 import math
+from typing import Optional, Generic, TypeVar
 
 from reprit.base import generate_repr
 
 from .bounding_box import BoundingBox
-from .hints import Scalar
+from .hints import (Scalar, T)
 
 
-class Point:
-    __slots__ = '_x', '_y'
+T = T
 
-    def __init__(self, x: Scalar, y: Scalar) -> None:
+class Point(Generic[T]):
+    __slots__ = '_x', '_y', '_user'
+
+    def __init__(self, x: Scalar, y: Scalar, user: Optional[T]=None) -> None:
         self._x = x
         self._y = y
+        self._user = user
 
     __repr__ = generate_repr(__init__)
 
@@ -31,6 +35,10 @@ class Point:
     @property
     def y(self) -> Scalar:
         return self._y
+
+    @property
+    def user(self):
+        return self._user
 
     def distance_to(self, other: 'Point') -> Scalar:
         return math.sqrt((self._x - other._x) ** 2 + (self._y - other._y) ** 2)

--- a/martinez/polygon.py
+++ b/martinez/polygon.py
@@ -1,24 +1,26 @@
 from functools import reduce
 from operator import add
 from typing import (Iterator,
+                    Generic,
                     List)
 
 from reprit.base import generate_repr
 
 from .bounding_box import BoundingBox
 from .contour import Contour
+from .hints import T
 
 
-class Polygon:
+class Polygon(Generic[T]):
     __slots__ = '_contours',
 
-    def __init__(self, contours: List[Contour]) -> None:
+    def __init__(self, contours: List[Contour[T]]) -> None:
         self._contours = contours
 
     __repr__ = generate_repr(__init__)
 
     @property
-    def contours(self) -> List[Contour]:
+    def contours(self) -> List[Contour[T]]:
         return self._contours
 
     def __eq__(self, other: 'Polygon') -> bool:
@@ -26,7 +28,7 @@ class Polygon:
                 if isinstance(other, Polygon)
                 else NotImplemented)
 
-    def __iter__(self) -> Iterator[Contour]:
+    def __iter__(self) -> Iterator[Contour[T]]:
         return iter(self._contours)
 
     @property

--- a/martinez/segment.py
+++ b/martinez/segment.py
@@ -1,21 +1,23 @@
 from operator import attrgetter
+from typing import Generic
 
 from reprit.base import generate_repr
 
+from .hints import T
 from .point import Point
 
 points_key = attrgetter('x', 'y')
 
 
-class Segment:
+class Segment(Generic[T]):
     __slots__ = '_source', '_target'
 
-    def __init__(self, source: Point, target: Point):
+    def __init__(self, source: Point[T], target: Point[T]):
         self._source = source
         self._target = target
 
     @property
-    def source(self) -> Point:
+    def source(self) -> Point[T]:
         return self._source
 
     @property
@@ -48,5 +50,5 @@ class Segment:
         return self._source.x == self._target.x
 
     @property
-    def reversed(self) -> 'Segment':
-        return Segment(self._target, self._source)
+    def reversed(self) -> 'Segment[T]':
+        return Segment[T](self._target, self._source)

--- a/martinez/utilities.py
+++ b/martinez/utilities.py
@@ -3,7 +3,9 @@ from typing import (Optional,
                     Sequence,
                     Tuple)
 
-from .hints import Scalar
+from .hints import (Scalar,
+                    T,
+                    UserLerp)
 from .point import Point
 from .segment import Segment
 
@@ -39,8 +41,9 @@ def _find_intersections(u0: Scalar, u1: Scalar, v0: Scalar, v1: Scalar
         return 1, first_coefficient, second_coefficient
 
 
-def find_intersections(first_segment: Segment, second_segment: Segment,
+def find_intersections(first_segment: Segment[T], second_segment: Segment[T],
                        *,
+                       ulerp: Optional[UserLerp] = None,
                        threshold: float = 1e-8,
                        squared_inv_epsilon: int = 10 ** 7
                        ) -> Tuple[int, Optional[Point], Optional[Point]]:
@@ -67,8 +70,10 @@ def find_intersections(first_segment: Segment, second_segment: Segment,
         t = (e.x * first_vector.y - e.y * first_vector.x) / cross_product
         if (t < 0) or (t > 1):
             return 0, None, None
-        first_intersection_point = Point(first_source.x + s * first_vector.x,
-                                         first_source.y + s * first_vector.y)
+        first_intersection_point = Point(
+            first_source.x + s * first_vector.x,
+            first_source.y + s * first_vector.y,
+            ulerp(first_source.user, first_target.user, s) if ulerp else None)
         if first_intersection_point.distance_to(first_source) < threshold:
             first_intersection_point = first_source
         elif first_intersection_point.distance_to(first_target) < threshold:
@@ -97,10 +102,12 @@ def find_intersections(first_segment: Segment, second_segment: Segment,
      second_coefficient) = _find_intersections(0, 1, s_min, s_max)
     first_intersection_point = second_intersection_point = None
     if intersections_count:
-        first_intersection_point = Point(first_source.x
-                                         + first_coefficient * first_vector.x,
-                                         first_source.y
-                                         + first_coefficient * first_vector.y)
+        first_intersection_point = Point(
+            first_source.x
+            + first_coefficient * first_vector.x,
+            first_source.y
+            + first_coefficient * first_vector.y,
+            ulerp(first_source.user, first_target.user, first_coefficient) if ulerp else None)
         if first_intersection_point.distance_to(first_source) < threshold:
             first_intersection_point = first_source
         elif first_intersection_point.distance_to(first_target) < threshold:
@@ -110,12 +117,14 @@ def find_intersections(first_segment: Segment, second_segment: Segment,
         elif first_intersection_point.distance_to(second_target) < threshold:
             first_intersection_point = second_target
         if intersections_count > 1:
-            second_intersection_point = Point(first_source.x
-                                              + second_coefficient
-                                              * first_vector.x,
-                                              first_source.y
-                                              + second_coefficient
-                                              * first_vector.y)
+            second_intersection_point = Point(
+                first_source.x
+                + second_coefficient
+                * first_vector.x,
+                first_source.y
+                + second_coefficient
+                * first_vector.y,
+                ulerp(first_source.user, first_target.user, second_coefficient) if ulerp else None)
     return (intersections_count, first_intersection_point,
             second_intersection_point)
 

--- a/tests/port_tests/utilities_tests/test_find_intersections.py
+++ b/tests/port_tests/utilities_tests/test_find_intersections.py
@@ -37,3 +37,16 @@ def test_reversed(segment: PortedSegment) -> None:
     assert result[0] == (1 if segment.is_degenerate else 2)
     assert result[1] == segment.source
     assert implication(segment.is_degenerate, result[-1] is None)
+
+def test_ulerp():
+    seg_a = PortedSegment[float](PortedPoint(-1, 0, 10),
+                                 PortedPoint( 1, 0, 20))
+    seg_b = PortedSegment[float](PortedPoint( 0,-1, 100),
+                                 PortedPoint( 0, 1, 200))
+    count, pt_a, pt_b = find_intersections(
+        seg_a, seg_b, ulerp=lambda a, b, t: a + t*(b-a))
+    assert count == 1
+    assert pt_b is None
+    assert isinstance(pt_a, PortedPoint)
+    assert pt_a == PortedPoint(0, 0)
+    assert pt_a.user == 15


### PR DESCRIPTION
So the idea behind this is similar to what GLU tesselator is doing, where vertices may contain arbitrary user data, and user can provide optional interpolation function which is called when intersecting segments. In my use case, this user data is Z coordinate; I'm doing 2.5D polygon clipping, where the subject and clipping polygon are in 3D but for the purpose of clipping are transformed into XY plane.

https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluTessCallback.xml

See GLU_TESS_COMBINE.

I only implemented this in the python port so far, and the testing is suboptimal since I'm not familiar with hypothesis. But looking at the find_intersections tests, I don't see how it's testing the actual intersection algo, it seems to just test the data types of the result.

I also noticed that when running pytest --mypy , a lot of it is failing.